### PR TITLE
Add an option to skip installed package output (pip-sync does this)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ In `tox.ini` add:
 requires =
   tox-pip-sync
 
+[testenv]
 deps =
     tests: -r pinned-requirements.txt
     tests: -e .
@@ -86,6 +87,16 @@ In your `pyproject.toml`:
 # You can turn off this behavior if you want:
 skip_listing = false
 ```
+
+... or in your `tox.ini`:
+
+```ini
+[tox_pip_sync]
+skip_listing = false
+```
+
+If a value appears in both files, the `pyproject.toml` value will take
+precedence.
 
 Hacking
 -------

--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ get out of date.
  * Doing something fancy in `setup.py` to read the requirements from another
    location
 
+Options
+-------
+
+In your `pyproject.toml`:
+
+```toml
+[tool.tox.tox_pip_sync]
+# By default `tox-pip-sync` disables listing the contents of the env for speed.
+# You can turn off this behavior if you want:
+skip_listing = false
+```
+
 Hacking
 -------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.tox.tox_pip_sync]
+# By default `tox-pip-sync` disables listing the contents of the env for speed.
+# You can turn off this behavior if you want:
+skip_listing = true

--- a/src/tox_pip_sync/__init__.py
+++ b/src/tox_pip_sync/__init__.py
@@ -1,8 +1,19 @@
 import pluggy
 
+from tox_pip_sync._config import load_config
 from tox_pip_sync._pip_sync import clear_compiled_files, pip_sync
 
 hookimpl = pluggy.HookimplMarker("tox")
+
+
+@hookimpl
+def tox_configure(config):
+    """Load our configuration.
+
+    Called after command line options are parsed and ini-file has been read.
+    """
+
+    config.tox_pip_sync = load_config(config.setupdir)
 
 
 @hookimpl
@@ -25,6 +36,17 @@ def tox_testenv_install_deps(venv, action):
 
     # Let tox know we've handled this case
     return True
+
+
+@hookimpl
+def tox_runenvreport(venv, action):  # pylint: disable=unused-argument
+    """Get the installed packages and versions in this venv."""
+
+    if venv.envconfig.config.tox_pip_sync.get("skip_listing", True):
+        # This appears to be purely FYI, and just slows things down
+        return ["*** listing modules disabled by tox-pip-sync in pyproject.toml ***"]
+
+    return None
 
 
 @hookimpl

--- a/src/tox_pip_sync/__init__.py
+++ b/src/tox_pip_sync/__init__.py
@@ -44,7 +44,7 @@ def tox_runenvreport(venv, action):  # pylint: disable=unused-argument
 
     if venv.envconfig.config.tox_pip_sync.get("skip_listing", True):
         # This appears to be purely FYI, and just slows things down
-        return ["*** listing modules disabled by tox-pip-sync in pyproject.toml ***"]
+        return ["*** listing modules disabled by tox-pip-sync ***"]
 
     return None
 

--- a/src/tox_pip_sync/_config.py
+++ b/src/tox_pip_sync/_config.py
@@ -1,9 +1,23 @@
+from configparser import ConfigParser
+
 import toml
+
+TYPED_OPTIONS = {
+    # Option name:  (type, default)
+    "skip_listing": (bool, True)
+}
 
 
 def load_config(project_dir):
     """Load our config for a particular project."""
 
+    config = IniConfig.parse(project_dir / "tox.ini")
+    config.update(_parse_toml(project_dir))
+
+    return config
+
+
+def _parse_toml(project_dir):
     project_file = project_dir / "pyproject.toml"
     if not project_file.exists():
         return {}
@@ -14,3 +28,40 @@ def load_config(project_dir):
         return toml_config["tool"]["tox"]["tox_pip_sync"]
     except KeyError:
         return {}
+
+
+class IniConfig:
+    """Load settings from a tox.ini file."""
+
+    # pylint: disable=too-few-public-methods
+
+    @classmethod
+    def parse(cls, file_name):
+        """Load settings from a tox.ini file."""
+
+        parser = ConfigParser()
+        parser.read(file_name)
+
+        if "tox_pip_sync" not in parser:
+            return {}
+
+        values = dict(parser["tox_pip_sync"])
+        cls._coerce_values(values)
+
+        return values
+
+    @classmethod
+    def _coerce_values(cls, values):
+        # TOML has sane type handling, so this is only necessary for INI files
+        for key, (target_type, default) in TYPED_OPTIONS.items():
+            if key in values:
+                values[key] = cls._convert_ini_type(values[key], target_type, default)
+
+    @classmethod
+    def _convert_ini_type(cls, value, target_type, default):
+        if target_type == bool:
+            # This is handy data, but no nice way to access them as we want to
+            # We don't want to deal with `ConfigParser`'s section objects.
+            return ConfigParser.BOOLEAN_STATES.get(value, default)
+
+        return value  # pragma: no cover

--- a/src/tox_pip_sync/_config.py
+++ b/src/tox_pip_sync/_config.py
@@ -1,0 +1,16 @@
+import toml
+
+
+def load_config(project_dir):
+    """Load our config for a particular project."""
+
+    project_file = project_dir / "pyproject.toml"
+    if not project_file.exists():
+        return {}
+
+    toml_config = toml.load(project_file)
+
+    try:
+        return toml_config["tool"]["tox"]["tox_pip_sync"]
+    except KeyError:
+        return {}

--- a/tests/unit/_config_test.py
+++ b/tests/unit/_config_test.py
@@ -1,0 +1,26 @@
+from tox_pip_sync import load_config
+
+
+class TestLoadConfig:
+    def test_it_can_read_the_project_file(self, tmpdir):
+        project_file = tmpdir / "pyproject.toml"
+        project_file.write_text(
+            "[tool.tox.tox_pip_sync]\na_setting = true", encoding="utf-8"
+        )
+
+        settings = load_config(tmpdir)
+
+        assert settings == {"a_setting": True}
+
+    def test_it_can_handle_the_section_being_missing(self, tmpdir):
+        project_file = tmpdir / "pyproject.toml"
+        project_file.write_text("", encoding="utf-8")
+
+        settings = load_config(tmpdir)
+
+        assert settings == {}
+
+    def test_it_can_handle_the_file_being_missing(self, tmpdir):
+        settings = load_config(tmpdir)
+
+        assert settings == {}

--- a/tests/unit/_config_test.py
+++ b/tests/unit/_config_test.py
@@ -1,26 +1,60 @@
+import pytest
+
 from tox_pip_sync import load_config
 
 
 class TestLoadConfig:
-    def test_it_can_read_the_project_file(self, tmpdir):
-        project_file = tmpdir / "pyproject.toml"
-        project_file.write_text(
-            "[tool.tox.tox_pip_sync]\na_setting = true", encoding="utf-8"
-        )
+    @pytest.mark.parametrize(
+        "file_name,content,expected_values",
+        (
+            (
+                "pyproject.toml",
+                "[tool.tox.tox_pip_sync]\na_setting = true",
+                {"a_setting": True},
+            ),
+            ("tox.ini", "[tox_pip_sync]\na_setting = true", {"a_setting": "true"}),
+        ),
+    )
+    def test_it_can_read_from_a_file(self, tmpdir, file_name, content, expected_values):
+        config_file = tmpdir / file_name
+        config_file.write_text(content, encoding="utf-8")
 
         settings = load_config(tmpdir)
 
-        assert settings == {"a_setting": True}
+        assert settings == expected_values
 
-    def test_it_can_handle_the_section_being_missing(self, tmpdir):
-        project_file = tmpdir / "pyproject.toml"
+    @pytest.mark.parametrize("file_name", ("pyproject.toml", "tox.ini"))
+    def test_it_can_handle_the_section_being_missing(self, tmpdir, file_name):
+        project_file = tmpdir / file_name
         project_file.write_text("", encoding="utf-8")
 
         settings = load_config(tmpdir)
 
         assert settings == {}
 
-    def test_it_can_handle_the_file_being_missing(self, tmpdir):
+    def test_it_can_handle_the_files_being_missing(self, tmpdir):
         settings = load_config(tmpdir)
 
         assert settings == {}
+
+    @pytest.mark.parametrize(
+        "option,value,expected",
+        (
+            ("skip_listing", "1", True),
+            ("skip_listing", "0", False),
+            ("skip_listing", "true", True),
+            ("skip_listing", "false", False),
+            ("skip_listing", "on", True),
+            ("skip_listing", "off", False),
+            ("skip_listing", "True", True),
+            # Note this isn't part of what ConfigParser considers falsy
+            ("skip_listing", "False", True),
+        ),
+    )
+    def test_it_coerces_values_for_ini_files(self, tmpdir, option, value, expected):
+        tox_ini = tmpdir / "tox.ini"
+        tox_ini.write_text(f"[tox_pip_sync]\n{option} = {value}", encoding="utf-8")
+
+        settings = load_config(tmpdir)
+
+        assert settings == {option: expected}

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,9 @@ requires =
   tox-run-command
 tox_pyenv_fallback = false
 
+[tox_pip_sync]
+skip_listing = true
+
 [testenv]
 skip_install = true
 sitepackages = {env:SITE_PACKAGES:false}


### PR DESCRIPTION
The output here is mostly FYI, as far as I can tell it doesn't actually serve a purpose in tox. This shaves about 0.3-0.5s off a run per environment. So a small but decent saving for something like `make sure`.

`pip-sync` also gives a pretty good account of what happened in a virtual env if you want to look.

Kind of amazingly it seems like `tox` does not provide a way of providing custom settings from the `tox.ini` file to plugins. `tox-pip-extensions` for example just parses the `tox.ini` file again from scratch itself. If we're only going to do one, we should follow `tox` and our own newer tools and prioritise `pyproject.toml` over `tox.ini`