### PR TITLE
Add hashing functions to speed up normal usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ In your `pyproject.toml`:
 # By default `tox-pip-sync` disables listing the contents of the env for speed.
 # You can turn off this behavior if you want:
 skip_listing = false
+
+# Once we succesfully install the dependencies for a virtual env, we will store
+# a hash of them. If nothing changes we won't attempt to resync the virtual
+# environment, which can save several seconds. You disable this so the
+# environment is synced every time by setting this to `false`
+enable_hashing = true
 ```
 
 ... or in your `tox.ini`:
@@ -93,6 +99,7 @@ skip_listing = false
 ```ini
 [tox_pip_sync]
 skip_listing = false
+enable_hashing = true
 ```
 
 If a value appears in both files, the `pyproject.toml` value will take

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,9 @@
 # By default `tox-pip-sync` disables listing the contents of the env for speed.
 # You can turn off this behavior if you want:
 skip_listing = true
+
+# Once we succesfully install the dependencies for a virtual env, we will store
+# a hash of them. If nothing changes we won't attempt to resync the virtual
+# environment, which can save several seconds. You disable this so the
+# environment is synced every time by setting this to `false`
+enable_hashing = true

--- a/src/tox_pip_sync/__init__.py
+++ b/src/tox_pip_sync/__init__.py
@@ -31,7 +31,8 @@ def tox_testenv_install_deps(venv, action):
     """Perform install dependencies action for this venv."""
 
     # Call our pip sync method instead of the usual way to install dependencies
-    pip_sync(venv, action)
+    config = venv.envconfig.config.tox_pip_sync
+    pip_sync(venv, action, skip_on_hash_match=config.get("enable_hashing", True))
     venv.pip_synced = True
 
     # Let tox know we've handled this case
@@ -42,9 +43,10 @@ def tox_testenv_install_deps(venv, action):
 def tox_runenvreport(venv, action):  # pylint: disable=unused-argument
     """Get the installed packages and versions in this venv."""
 
-    if venv.envconfig.config.tox_pip_sync.get("skip_listing", True):
+    config = venv.envconfig.config.tox_pip_sync
+    if config.get("skip_listing", True):
         # This appears to be purely FYI, and just slows things down
-        return ["*** listing modules disabled by tox-pip-sync ***"]
+        return ["*** listing modules disabled by tox-pip-sync in pyproject.toml ***"]
 
     return None
 

--- a/src/tox_pip_sync/_pip_sync.py
+++ b/src/tox_pip_sync/_pip_sync.py
@@ -1,4 +1,6 @@
+import json
 import os
+from functools import lru_cache
 from glob import glob
 from os.path import relpath
 from pathlib import Path
@@ -8,16 +10,31 @@ from tox.reporter import verbosity1
 from tox_pip_sync._requirements import RequirementList
 
 
-def pip_sync(venv, action):
+def pip_sync(venv, action, skip_on_hash_match=True):
     """Use pip-sync to ensure requirements are up to date in a virtual env."""
+
+    requirements = RequirementList.from_strings(
+        (dep.name for dep in venv.envconfig.deps)
+    )
+    current_hash = requirements.hash(root_dir=venv.envconfig.config.setupdir)
+    env_data = EnvData(venv.path)
+
+    if skip_on_hash_match:
+        last_hash = env_data.last_hash
+        if last_hash == current_hash:
+            verbosity1("Skipping pip-sync, as hash has not changed")
+            return
 
     pip_tools_run(
         "pip-sync",
-        list(requirements_files_for_env(venv, action)),
+        list(requirements_files_for_env(venv, action, requirements)),
         message="Syncing virtual env with pip-sync",
         venv=venv,
         action=action,
     )
+
+    # Store the results of this run
+    env_data.save(requirements_hash=current_hash)
 
 
 def pip_tools_run(exe_name, arguments, message, venv, action):
@@ -48,16 +65,12 @@ def pip_tools_run(exe_name, arguments, message, venv, action):
     )
 
 
-def requirements_files_for_env(venv, action):
+def requirements_files_for_env(venv, action, requirements):
     """Return requirements files for a tox virtual env.
 
     This will read, create or invent them as necessary to provide files for
     `pip-sync` to work with.
     """
-
-    requirements = RequirementList.from_strings(
-        (dep.name for dep in venv.envconfig.deps)
-    )
 
     for req in requirements:
         # Yield out any requirements like '-r filename.txt'. We'll assume they
@@ -70,7 +83,8 @@ def requirements_files_for_env(venv, action):
 
 
 def _pinned_file_for_requirements(venv, action, requirements):
-    stub = "tox-pip-sync_" + requirements.hash(root_dir=venv.envconfig.config.setupdir)
+    requirements_hash = requirements.hash(root_dir=venv.envconfig.config.setupdir)
+    stub = "tox-pip-sync_" + requirements_hash
 
     pinned = venv.path / stub + ".txt"
     if pinned.exists():
@@ -106,3 +120,32 @@ def clear_compiled_files(venv):
     # We can't find what we're looking for, so clear out any stale files
     for old_files in glob(str(venv.path / "tox-pip-sync_*")):
         os.remove(old_files)
+
+
+class EnvData:
+    """Class for accessing data stored in a testenv by and for tox-pip-sync."""
+
+    def __init__(self, venv_path):
+        """Initialize an EnvData object.
+
+        :param venv_path: The path to the root of the virtual env.
+        """
+        self.path = venv_path / "tox-pip-sync.json"
+
+    @property
+    def last_hash(self):
+        """Get the last hash stored in the data."""
+
+        return self._load().get("hash")
+
+    def save(self, requirements_hash):
+        """Save the hash."""
+
+        self.path.write_text(json.dumps({"hash": requirements_hash}), encoding="utf-8")
+
+    @lru_cache(1)
+    def _load(self):
+        if not self.path.exists():
+            return {}
+
+        return json.loads(self.path.read_text(encoding="utf-8"))

--- a/tests/unit/__init___test.py
+++ b/tests/unit/__init___test.py
@@ -60,9 +60,13 @@ class TestToxTestenvCreate:
 
 class TestToxTestenvInstallDeps:
     def test_it(self, venv, action, pip_sync):
+        venv.envconfig.config.tox_pip_sync = {"enable_hashing": sentinel.enable_hashing}
+
         result = tox_testenv_install_deps(venv, action)
 
-        pip_sync.assert_called_once_with(venv, action)
+        pip_sync.assert_called_once_with(
+            venv, action, skip_on_hash_match=sentinel.enable_hashing
+        )
 
         assert venv.pip_synced
         assert result

--- a/tests/unit/_pip_sync_test.py
+++ b/tests/unit/_pip_sync_test.py
@@ -1,20 +1,29 @@
+import json
 from pathlib import Path
+from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
 from tox.config import DepConfig
 
 from tox_pip_sync import pip_sync
-from tox_pip_sync._pip_sync import pip_tools_run, requirements_files_for_env
+from tox_pip_sync._pip_sync import EnvData, pip_tools_run, requirements_files_for_env
+from tox_pip_sync._requirements import PipRequirement
 
 # This test is heavily based on accessing underscored items
 # pylint: disable=protected-access
 
 
 class TestRequirementsFilesForEnv:
-    def test_it_passes_through_requirements_files(self, requirements_files, venv):
+    def test_it_passes_through_requirements_files(
+        self, requirements_files, requirements_list
+    ):
         # tox smooshes together the -r and the filename for some reason
-        venv.envconfig.deps = [DepConfig("-rreq_1.txt"), DepConfig("-creq_2.txt")]
+        requirements_list.needs_compilation = False
+        requirements_list.__iter__.return_value = [
+            PipRequirement("-rreq_1.txt"),
+            PipRequirement("-creq_2.txt"),
+        ]
 
         results = requirements_files()
 
@@ -27,15 +36,14 @@ class TestRequirementsFilesForEnv:
     def test_it_compiles_normal_dependencies(
         self,
         requirements_files,
-        requirements_set,
+        requirements_list,
         venv,
         action,
         pip_tools_run,
         dependency,
     ):  # pylint: disable=too-many-arguments
-        requirements_set.needs_compilation.return_value = True
-
-        venv.envconfig.deps = [DepConfig(dependency)]
+        requirements_list.needs_compilation.return_value = True
+        requirements_list.__iter__.return_value = [PipRequirement(dependency)]
 
         file_names = requirements_files()
 
@@ -51,17 +59,18 @@ class TestRequirementsFilesForEnv:
         assert file_names[0] == str(venv.path / "tox-pip-sync_0000.txt")
 
     def test_it_writes_the_requirements_out_to_be_compiled(
-        self, requirements_files, requirements_set, RequirementList, venv
+        self, requirements_files, requirements_list, venv
     ):
-        requirements_set.constrained_set.return_value = ["some_output", 0]
-        venv.envconfig.deps = [DepConfig("-creqs.txt"), DepConfig(".[tests]")]
+        requirements_list.needs_compilation.return_value = True
+        requirements_list.constrained_set.return_value = ["some_output", 0]
+        requirements_list.__iter__.return_value = [
+            PipRequirement("-creqs.txt"),
+            PipRequirement(".[tests]"),
+        ]
 
         requirements_files()
 
-        RequirementList.from_strings.assert_called_once_with(
-            Any.generator.containing(["-creqs.txt", ".[tests]"]).only()
-        )
-        requirements_set.constrained_set.assert_called_once_with(
+        requirements_list.constrained_set.assert_called_once_with(
             # This path is the difference between the venv dir and the project
             # root
             Path("../../")
@@ -69,11 +78,11 @@ class TestRequirementsFilesForEnv:
         unpinned = venv.path / "tox-pip-sync_0000.in"
         assert unpinned.read() == "some_output\n0"
 
-    @pytest.mark.usefixtures("requirements_set")
+    @pytest.mark.usefixtures("requirements_list")
     def test_it_re_uses_existing_files_when_compiling(
-        self, requirements_files, venv, pip_tools_run
+        self, requirements_files, venv, pip_tools_run, requirements_list
     ):
-        venv.envconfig.deps = [DepConfig(".")]
+        requirements_list.__iter__.return_value = [PipRequirement(".")]
         pinned_file = venv.path / "tox-pip-sync_0000.txt"
         pinned_file.write(".")
 
@@ -82,11 +91,14 @@ class TestRequirementsFilesForEnv:
         assert file_names[0] == pinned_file
         pip_tools_run.assert_not_called()
 
-    def test_it_cleans_up_old_files_when_compiling(self, requirements_files, venv):
-        venv.envconfig.deps = [DepConfig(".")]
-        old_pinned_file = venv.path / "tox-pip-sync_0000.txt"
+    def test_it_cleans_up_old_files_when_compiling(
+        self, requirements_files, venv, requirements_list
+    ):
+        requirements_list.__iter__.return_value = [PipRequirement(".")]
+        requirements_list.hash.return_value = "0000"
+        old_pinned_file = venv.path / "tox-pip-sync_1111.txt"
         old_pinned_file.write(".")
-        old_unpinned_file = venv.path / "tox-pip-sync_0000.in"
+        old_unpinned_file = venv.path / "tox-pip-sync_1111.in"
         old_unpinned_file.write(".")
 
         requirements_files()
@@ -95,30 +107,27 @@ class TestRequirementsFilesForEnv:
         assert not old_unpinned_file.exists()
 
     def test_it_raises_if_pip_compile_fails_to_create_the_expected_file(
-        self, venv, requirements_files, pip_tools_run
+        self, requirements_files, pip_tools_run, requirements_list
     ):
         pip_tools_run.side_effect = None
-        venv.envconfig.deps = [DepConfig(".")]
+        requirements_list.__iter__.return_value = [PipRequirement(".")]
 
         with pytest.raises(FileNotFoundError):
             requirements_files()
 
     @pytest.fixture
-    def requirements_files(self, venv, action):
+    def requirements_files(self, venv, action, requirements_list):
         def requirements_files():
-            return list(requirements_files_for_env(venv, action))
+            return list(requirements_files_for_env(venv, action, requirements_list))
 
         return requirements_files
 
     @pytest.fixture
-    def requirements_set(self, RequirementList):
-        requirements_set = RequirementList.from_strings.return_value
-        requirements_set.hash.return_value = "0000"
-        return requirements_set
-
-    @pytest.fixture
-    def RequirementList(self, patch):
-        return patch("tox_pip_sync._pip_sync.RequirementList")
+    def requirements_list(self, patch):
+        RequirementList = patch("tox_pip_sync._pip_sync.RequirementList")
+        requirements_list = RequirementList.from_strings.return_value
+        requirements_list.hash.return_value = "0000"
+        return requirements_list
 
     @pytest.fixture(autouse=True)
     def pip_tools_run(self, patch):
@@ -177,21 +186,93 @@ class TestPipToolsRun:
 
 
 class TestPipSync:
-    def test_it(self, pip_tools_run, requirements_files_for_env, venv, action):
-        # RequirementsFiles is a context manager
+    def test_it(
+        self, pip_tools_run, requirements_files_for_env, venv, action, RequirementList
+    ):  # pylint: disable=too-many-arguments
         requirements_files_for_env.return_value = ("requirements.txt",)
+        venv.envconfig.deps = [DepConfig("package_name")]
 
-        pip_sync(venv, action)
+        pip_sync(venv, action, skip_on_hash_match=False)
 
-        requirements_files_for_env.assert_called_once_with(venv, action)
+        RequirementList.from_strings.assert_called_once_with(
+            Any.generator.containing(["package_name"])
+        )
+        requirements_files_for_env.assert_called_once_with(
+            venv, action, RequirementList.from_strings.return_value
+        )
         pip_tools_run.assert_called_once_with(
             "pip-sync", ["requirements.txt"], message=Any(), venv=venv, action=action
         )
 
-    @pytest.fixture
+    def test_it_skips_if_hashes_match(
+        self, venv, action, RequirementList, EnvData, pip_tools_run
+    ):  # pylint: disable=too-many-arguments
+        requirements = RequirementList.from_strings.return_value
+        requirements.hash.return_value = sentinel.matching_hash_value
+        EnvData.return_value.last_hash = sentinel.matching_hash_value
+
+        pip_sync(venv, action, skip_on_hash_match=True)
+
+        pip_tools_run.assert_not_called()
+
+    def test_it_runs_if_hashes_differ(
+        self, venv, action, RequirementList, EnvData, pip_tools_run
+    ):  # pylint: disable=too-many-arguments
+        requirements = RequirementList.from_strings.return_value
+        requirements.hash.return_value = sentinel.hash_value_1
+        EnvData.return_value.last_hash = sentinel.hash_value_2
+
+        pip_sync(venv, action, skip_on_hash_match=True)
+
+        pip_tools_run.assert_called_once()
+
+    @pytest.mark.usefixtures("pip_tools_run")
+    def test_it_saves_the_hash(self, venv, action, RequirementList, EnvData):
+        pip_sync(venv, action, skip_on_hash_match=True)
+
+        requirements = RequirementList.from_strings.return_value
+        requirements.hash.assert_called_once_with(
+            root_dir=venv.envconfig.config.setupdir
+        )
+
+        EnvData.assert_called_once_with(venv.path)
+        EnvData.return_value.save.assert_called_once_with(
+            requirements_hash=requirements.hash.return_value
+        )
+
+    @pytest.fixture(autouse=True)
     def pip_tools_run(self, patch):
         return patch("tox_pip_sync._pip_sync.pip_tools_run")
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def requirements_files_for_env(self, patch):
         return patch("tox_pip_sync._pip_sync.requirements_files_for_env")
+
+    @pytest.fixture(autouse=True)
+    def RequirementList(self, patch):
+        return patch("tox_pip_sync._pip_sync.RequirementList")
+
+    @pytest.fixture(autouse=True)
+    def EnvData(self, patch):
+        return patch("tox_pip_sync._pip_sync.EnvData")
+
+
+class TestEnvData:
+    def test_it_can_load_the_hash(self, tmpdir):
+        (tmpdir / "tox-pip-sync.json").write_text(
+            json.dumps({"hash": "value"}), "utf-8"
+        )
+        last_hash = EnvData(tmpdir).last_hash
+
+        assert last_hash == "value"
+
+    def test_it_fails_gracefully_if_the_file_is_missing(self, tmpdir):
+        last_hash = EnvData(tmpdir).last_hash
+
+        assert last_hash is None
+
+    def test_it_can_save_the_hash(self, tmpdir):
+        EnvData(tmpdir).save(requirements_hash="value")
+
+        content = json.loads((tmpdir / "tox-pip-sync.json").read_text("utf-8"))
+        assert content == {"hash": "value"}


### PR DESCRIPTION
For: https://github.com/hypothesis/tox-pip-sync/issues/14

This PR adds hashing as a matter of course. This means we will:

 * Create a hash of the dependencies the last time we synced
 * Calculate the hash now
 * Only trigger re-syncing if the two are different

This _**does not detect changes in the tox env itself**_. So if you mess with the tox env manually, it'll stay as it is until the next sync is triggered. You can remove the tox env entirely to "fix" this. I think this is actually handy behavior as you can install things in to test them etc.

You can control this behavior by setting the `enable_hashing` setting in `pyproject.toml`

## Example benefits

To test this I ran `time make format sure` in `h-matchers`. This was run a couple of times to ensure the tox envs were all created first:

 * Time with `tox-pip-sync` from master: 22.3s
 * This branch (first run): 22.2s
 * This branch (second run): 15.6s (30% saving)
 
A second example of a frequently run command without any Make overhead `tox -e tests`:

 * Time with `tox-pip-sync` from master: 5.9s
 * This branch (first run): 5.8s
 * This branch (second run): 3.3s  (43% saving)

## What we hash

Things the hash depends on (and should notice changing):

 * Project files: `pyproject.toml`, `setup.py`, `setup.cfg`
 * Any dependencies specified directly in `tox.ini`
 * Any dependencies in `requirements.txt` files

## Testing notes

Pick a library and an app and repeat for both:

 * `tox -e tests --run-command echo` - Just to get the environment up and running first
 * `.tox/.tox/bin/pip install -e ~/my_projects_dir/tox_pip_sync`
 * `time tox -v -e tests --run-command echo` 
 * You should see a comment about the project being re-synced
 * `time tox -v -e tests --run-command echo` 
 * You should not see a comment about the project being re-synced and if should be faster
 * Try changing any of the things and re-run
 * `time tox -v -e tests --run-command echo` 
 * You should see a comment about the project being re-synced