### PR TITLE
Set the relative path to constrained files correctly when compiling

### DIFF
--- a/src/tox_pip_sync/_pip_sync.py
+++ b/src/tox_pip_sync/_pip_sync.py
@@ -1,5 +1,7 @@
 import os
 from glob import glob
+from os.path import relpath
+from pathlib import Path
 
 from tox.reporter import verbosity1
 
@@ -79,7 +81,8 @@ def _pinned_file_for_requirements(venv, action, requirements):
     clear_compiled_files(venv)
 
     # Create a new version and compile it
-    constrained = requirements.constrained_set()
+    relative_root = Path(relpath(venv.envconfig.config.setupdir, venv.path))
+    constrained = requirements.constrained_set(relative_root)
     unpinned = venv.path / stub + ".in"
     unpinned.write_text("\n".join(str(dep) for dep in constrained), encoding="utf-8")
 

--- a/tests/unit/_pip_sync_test.py
+++ b/tests/unit/_pip_sync_test.py
@@ -61,7 +61,11 @@ class TestRequirementsFilesForEnv:
         RequirementList.from_strings.assert_called_once_with(
             Any.generator.containing(["-creqs.txt", ".[tests]"]).only()
         )
-        requirements_set.constrained_set.assert_called_once_with()
+        requirements_set.constrained_set.assert_called_once_with(
+            # This path is the difference between the venv dir and the project
+            # root
+            Path("../../")
+        )
         unpinned = venv.path / "tox-pip-sync_0000.in"
         assert unpinned.read() == "some_output\n0"
 
@@ -168,11 +172,8 @@ class TestPipToolsRun:
         return request.param
 
     @pytest.fixture(autouse=True)
-    def bin_dir(self, tmpdir):
-        bin_dir = tmpdir / "bin"
-        bin_dir.mkdir()
-
-        return bin_dir
+    def bin_dir(self, venv):
+        return venv.envconfig.envbindir
 
 
 class TestPipSync:

--- a/tests/unit/_requirements_test.py
+++ b/tests/unit/_requirements_test.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from h_matchers import Any
 
@@ -62,12 +64,13 @@ class TestRequirementsList:
         req_set = RequirementList.from_strings(
             ["-r requirements.txt", "-c constrained.txt", "-e editable", "package"]
         )
+        rel_root = Path("../..")
 
-        assert req_set.constrained_set() == RequirementList.from_strings(
+        assert req_set.constrained_set(rel_root) == RequirementList.from_strings(
             [
-                "-c requirements.txt",  # <<< The change is the -c here
-                "-c constrained.txt",
-                "-e editable",
+                "-c ../../requirements.txt",  # <<< The change is the -c here
+                "-c ../../constrained.txt",
+                "-e editable",  # <<< Note this isn't relative to rel_root
                 "package",
             ]
         )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -27,7 +27,15 @@ def venv(tmpdir):
     # things onto this as it runs in tox
     venv = create_autospec(venv_model, instance=True)
     venv._pcall.return_value = "Some command output"  # pylint: disable=protected-access
-    venv.envconfig.envbindir = tmpdir / "bin"
-    venv.path = tmpdir
+
+    venv.path = tmpdir / ".tox"
+    venv.path.mkdir()
+    venv.path = venv.path / "venv"
+    venv.path.mkdir()
+
+    venv.envconfig.envbindir = venv.path / "bin"
+    venv.envconfig.envbindir.mkdir()
+
+    venv.envconfig.config.setupdir = tmpdir
 
     return venv


### PR DESCRIPTION
It turns out this had been tested on libraries with ad-hoc dependencies like `-e .` and products with dependency files like `-r requirements/dev.txt` but never with both at the same time.

It also turns out that `pip-compile` resolves the relative paths completely differently in both cases:

 * For `-e .` the path is assessed relative to the current working directory
 * For `-r filename.txt` the path is assessed relative to the file containing the reference (this is the bug fixed here)

## Testing notes

Try this out in a project like `viahtml` with both:

 * Checkout this specific commit: https://github.com/hypothesis/viahtml/pull/163/commits/c4ef0b26ef6e129a0dc7e10bab504a92b039e52d
 * Run `make dev` (this may fail... that's ok)
 * Run `.tox/.tox/bin/pip install -e ../tox-pip-sync` - Install this version temporarily
 * Run `make dev`  - This should work