### PR TITLE
Don't assume requirements files are relative paths

### DIFF
--- a/src/tox_pip_sync/_requirements.py
+++ b/src/tox_pip_sync/_requirements.py
@@ -83,9 +83,14 @@ class RequirementList(list):
                 # pylint: disable=protected-access
                 # This is an instance of this class, making this fine...
 
-                yield from self.from_requirements_file(
-                    root_dir / req.filename
-                )._hash_fragments(root_dir)
+                filename = req.filename
+                # If this is a relative path, make it relative to the root
+                if not filename.startswith("/"):
+                    filename = root_dir / req.filename
+
+                yield from self.from_requirements_file(filename)._hash_fragments(
+                    root_dir
+                )
 
             if req.is_local:
                 yield from self._hash_fragments_for_project(root_dir)

--- a/tests/unit/_requirements_test.py
+++ b/tests/unit/_requirements_test.py
@@ -100,7 +100,9 @@ class TestRequirementsSetHashing:
 
         assert get_hash()
 
-    @pytest.mark.parametrize("file_name", ("requirements.txt", "child-reqs.txt"))
+    @pytest.mark.parametrize(
+        "file_name", ("requirements.txt", "child-reqs.txt", "absolute-reqs.txt")
+    )
     def test_it_detects_changes_to_requirements_files(
         self, get_hash, project_dir, file_name
     ):
@@ -130,7 +132,8 @@ class TestRequirementsSetHashing:
 
     @pytest.fixture
     def project_reqs(self, project_dir):  # pylint: disable=unused-argument
-        return ["-r child-reqs.txt", ".", "package_3==2.2.2"]
+        abs_reqs = project_dir / "absolute-reqs.txt"
+        return ["-r child-reqs.txt", f"-r {abs_reqs}", ".", "package_3==2.2.2"]
 
     @pytest.fixture
     def project_dir(self, tmpdir):
@@ -143,6 +146,9 @@ class TestRequirementsSetHashing:
 
         reqs = tmpdir / "child-reqs.txt"
         reqs.write_text("-r requirements.txt\npackage_2=2.2.2", encoding="utf-8")
+
+        reqs = tmpdir / "absolute-reqs.txt"
+        reqs.write_text("package==3.3.4", encoding="utf-8")
 
         return tmpdir
 


### PR DESCRIPTION
For: https://github.com/hypothesis/tox-pip-sync/issues/12

Previously we always assumed that requirements files are relative to the project root. This means when `hdev` injects it's dependencies we end up with nonsense paths which crash out with `FileNotFound`.

To make matters worse `tox` interprets this as it's own error and emits a very unhelpful warning:

> Error creating virtualenv. Note that spaces in path are not supported by virtualenv.

If you want to see this fail in the tests you can easily do this by rolling back the fix, but not the tests. They demonstrate the failure reasonably well now.