### PR TITLE
Add a workaround for pip / pip-tools incompatibility

### DIFF
--- a/src/tox_pip_sync/_pip_sync.py
+++ b/src/tox_pip_sync/_pip_sync.py
@@ -49,6 +49,10 @@ def pip_tools_run(exe_name, arguments, message, venv, action):
         # being picked up via `--sitepackages`
         venv._install(["pip-tools", "--force"], action=action)
 
+        # Work around a bug in `pip-tools`:
+        # https://github.com/jazzband/pip-tools/issues/1558
+        venv._install(["pip<22", "--force"], action=action)
+
         assert exe_path.exists(), (
             f"Expected executable '{exe_path}' was not installed "
             "as a result of installing `pip-tools`"

--- a/tests/unit/tox_pip_sync/_config_test.py
+++ b/tests/unit/tox_pip_sync/_config_test.py
@@ -30,12 +30,12 @@ class TestLoadConfig:
 
         settings = load_config(tmpdir)
 
-        assert settings == {}
+        assert not settings
 
     def test_it_can_handle_the_files_being_missing(self, tmpdir):
         settings = load_config(tmpdir)
 
-        assert settings == {}
+        assert not settings
 
     @pytest.mark.parametrize(
         "option,value,expected",

--- a/tests/unit/tox_pip_sync/_pip_sync_test.py
+++ b/tests/unit/tox_pip_sync/_pip_sync_test.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from unittest.mock import sentinel
+from unittest.mock import call, sentinel
 
 import pytest
 from h_matchers import Any
@@ -170,7 +170,12 @@ class TestPipToolsRun:
 
         pip_tools_run(exe_name, ["args"], message="any", venv=venv, action=action)
 
-        venv._install.assert_called_once_with(["pip-tools", "--force"], action=action)
+        venv._install.assert_has_calls(
+            [
+                call(["pip-tools", "--force"], action=action),
+                call(["pip<22", "--force"], action=action),
+            ]
+        )
 
     def test_if_installing_pip_fails_we_raise(self, exe_name, venv, action):
         with pytest.raises(AssertionError):


### PR DESCRIPTION
This bug isn't our fault but it's still breaking the builds, so we need to work around it for how:

 * https://github.com/jazzband/pip-tools/issues/1558

You can replicate this by running `hdev requirements` in a project. To try this out you can use:

`.tox/.tox/bin/pip install <your project dir>/tox-pip-sync`

You may need to do this in the `tox-pip-sync` project to bootstrap it. In master you should see something like:

```python
  File "/home/you/projects/tox-pip-sync/.tox/format/lib/python3.9/site-packages/piptools/repositories/pypi.py", line 455, in _setup_logging
    assert isinstance(handler, logging.StreamHandler)
AssertionError
```

And then run `hdev requirements` in the project. To remove it delete your `.tox` dirs.